### PR TITLE
Fix bug curl not included in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./migrations ./migrations
 RUN cargo install --path .
 
 FROM alpine AS runtime
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl curl
 # App directory
 WORKDIR /app
 COPY ./migrations /app/migrations


### PR DESCRIPTION
The healthcheck relies on curl being installed within the dockerfile, added it as runtime dependency in the docker file